### PR TITLE
setup rollup build environment

### DIFF
--- a/packages/components/.gitignore
+++ b/packages/components/.gitignore
@@ -1,3 +1,4 @@
 lib
 .bsb.lock
 storybook-static/
+build/

--- a/packages/components/babel.config.js
+++ b/packages/components/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [["@babel/preset-react", { runtime: "automatic" }], "@babel/preset-typescript"],
+}

--- a/packages/components/index.js
+++ b/packages/components/index.js
@@ -1,5 +1,0 @@
-const test = require("@greenlabs/formula-design-token")
-
-console.log(test)
-
-module.exports = {}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@greenlabs/formula-components",
   "version": "0.1.0",
-  "main": "./index.js",
   "repository": {
     "type": "git",
     "url": "git@github.com:green-labs/formula-design-system.git",
@@ -9,16 +8,26 @@
   },
   "author": "Greenlabs Dev <developer@greenlabs.co.kr>",
   "private": true,
+  "main": "build/cjs/index.js",
+  "module": "build/esm/index.js",
+  "types": "build/ts/latest/src/index.d.ts",
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "rescript-storybook": "^2.0.1",
-    "rescript-webapi": "^0.6.1"
+    "react-dom": "^18.2.0"
   },
+  "files": [
+    "./build/**/*"
+  ],
   "devDependencies": {
     "@babel/core": "^7.18.13",
+    "@babel/preset-react": "^7.18.6",
+    "@babel/preset-typescript": "^7.18.6",
     "@mdx-js/react": "^1.6.22",
     "@rescript/react": "^0.10.3",
+    "@rollup/plugin-babel": "^5.3.1",
+    "@rollup/plugin-commonjs": "^22.0.2",
+    "@rollup/plugin-json": "^4.1.0",
+    "@rollup/plugin-node-resolve": "^14.1.0",
     "@storybook/addon-actions": "^6.5.10",
     "@storybook/addon-docs": "^6.5.10",
     "@storybook/addon-essentials": "^6.5.10",
@@ -30,14 +39,20 @@
     "@storybook/testing-library": "^0.0.13",
     "@types/react": "^18.0.20",
     "@vanilla-extract/css": "^1.9.0",
+    "@vanilla-extract/rollup-plugin": "^1.1.0",
     "@vanilla-extract/webpack-plugin": "^2.1.12",
     "babel-loader": "^8.2.5",
     "concurrently": "^7.3.0",
-    "rescript": "^10.0.0"
+    "rescript": "^10.0.0",
+    "rescript-webapi": "^0.6.1",
+    "rollup": "^2.79.0"
   },
   "scripts": {
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
+    "build:storybook": "build-storybook",
+    "build:js": "yarn clean && rollup -c",
+    "build:types": "tsc -b",
+    "clean": "rm -rf ./build",
     "re:build": "rescript build -with-deps",
     "re:watch": "rescript build -with-deps -w",
     "start": "concurrently -g -n re,storybook \"yarn re:watch\" \"yarn storybook\""

--- a/packages/components/rollup.config.mjs
+++ b/packages/components/rollup.config.mjs
@@ -1,0 +1,48 @@
+import { readFileSync } from "fs"
+import * as path from "path"
+
+import { vanillaExtractPlugin } from "@vanilla-extract/rollup-plugin"
+import { nodeResolve } from "@rollup/plugin-node-resolve"
+import { babel } from "@rollup/plugin-babel"
+import commonjs from "@rollup/plugin-commonjs"
+import json from "@rollup/plugin-json"
+
+const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url).pathname))
+
+const extensions = [".js", ".jsx", ".ts", ".tsx"]
+
+export default {
+  plugins: [
+    nodeResolve({ extensions }),
+    commonjs(),
+    babel({
+      extensions,
+      exclude: "node_modules/**",
+      babelHelpers: "bundled",
+      envName: "production",
+      targets: "last 1 chrome versions",
+    }),
+    json({
+      compact: true,
+    }),
+    vanillaExtractPlugin(),
+  ],
+  input: "./src/index.ts",
+  output: [
+    {
+      format: "cjs",
+      dir: path.dirname(pkg.main),
+      preserveModules: true,
+      preserveModulesRoot: "src",
+      entryFileNames: "[name][assetExtname].js",
+      exports: "named",
+    },
+    {
+      format: "esm",
+      dir: path.dirname(pkg.module),
+      preserveModules: true,
+      preserveModulesRoot: "src",
+      entryFileNames: "[name][assetExtname].js",
+    },
+  ],
+}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,0 +1,2 @@
+export { Button } from "./Button/Button.bs"
+export { Text } from "./Text/Text"


### PR DESCRIPTION
- #8 
- setup babel.config.js / etc.
- Next.js doesn't allow global css file to be loaded from `node_modules` [ref](https://nextjs.org/docs/messages/css-npm), therefore we need to inform users to pre-build via next-transpile-modules.