### PR TITLE
fix: 스토리북 Pretendard 폰트 적용

### DIFF
--- a/packages/components/.storybook/globalStyle.css
+++ b/packages/components/.storybook/globalStyle.css
@@ -1,0 +1,1 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css");

--- a/packages/components/.storybook/preview.js
+++ b/packages/components/.storybook/preview.js
@@ -1,3 +1,5 @@
+import "./globalStyle.css"
+
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {


### PR DESCRIPTION
작업내용
-
- 스토리북의 text component에 적용되는 폰트 제공을 위해, 글로벌스타일에서 `Pretendard`를 import합니다.