### PR TITLE
fix: split icon types

### DIFF
--- a/packages/components/src/Icon/.svgrrc.js
+++ b/packages/components/src/Icon/.svgrrc.js
@@ -15,10 +15,8 @@ module.exports = {
   svgProps: {
     width: "{finalSize}",
     height: "{finalSize}",
-    style: "{style}",
     fill: "{fill}",
     viewBox: "0 0 48 48",
-    className: "{className}",
   },
   replaceAttrValues: {
     "#1F2024": "{fill}",

--- a/packages/components/src/Icon/generated/ArrowDownLineBold.tsx
+++ b/packages/components/src/Icon/generated/ArrowDownLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowDownLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowDownLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowDownLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ArrowDownLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowDownLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowDownLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowDownLineThin.tsx
+++ b/packages/components/src/Icon/generated/ArrowDownLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowDownLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowDownLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowLeftLineBold.tsx
+++ b/packages/components/src/Icon/generated/ArrowLeftLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowLeftLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowLeftLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowLeftLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ArrowLeftLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowLeftLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowLeftLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowLeftLineThin.tsx
+++ b/packages/components/src/Icon/generated/ArrowLeftLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowLeftLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowLeftLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowRightLineBold.tsx
+++ b/packages/components/src/Icon/generated/ArrowRightLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowRightLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowRightLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowRightLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ArrowRightLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowRightLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowRightLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowRightLineThin.tsx
+++ b/packages/components/src/Icon/generated/ArrowRightLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowRightLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowRightLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowTriangleDownFill.tsx
+++ b/packages/components/src/Icon/generated/ArrowTriangleDownFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowTriangleDownFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowTriangleDownFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowTriangleDownLineBold.tsx
+++ b/packages/components/src/Icon/generated/ArrowTriangleDownLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowTriangleDownLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowTriangleDownLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowTriangleDownLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ArrowTriangleDownLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowTriangleDownLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowTriangleDownLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowTriangleDownLineThin.tsx
+++ b/packages/components/src/Icon/generated/ArrowTriangleDownLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowTriangleDownLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowTriangleDownLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowTriangleUpFill.tsx
+++ b/packages/components/src/Icon/generated/ArrowTriangleUpFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowTriangleUpFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowTriangleUpFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowTriangleUpLineBold.tsx
+++ b/packages/components/src/Icon/generated/ArrowTriangleUpLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowTriangleUpLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowTriangleUpLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowTriangleUpLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ArrowTriangleUpLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowTriangleUpLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowTriangleUpLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowTriangleUpLineThin.tsx
+++ b/packages/components/src/Icon/generated/ArrowTriangleUpLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowTriangleUpLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowTriangleUpLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowUpLineBold.tsx
+++ b/packages/components/src/Icon/generated/ArrowUpLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowUpLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowUpLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowUpLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ArrowUpLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowUpLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowUpLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ArrowUpLineThin.tsx
+++ b/packages/components/src/Icon/generated/ArrowUpLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgArrowUpLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgArrowUpLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/BookMarkFill.tsx
+++ b/packages/components/src/Icon/generated/BookMarkFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgBookMarkFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgBookMarkFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/BookMarkLineBold.tsx
+++ b/packages/components/src/Icon/generated/BookMarkLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgBookMarkLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgBookMarkLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/BookMarkLineRegular.tsx
+++ b/packages/components/src/Icon/generated/BookMarkLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgBookMarkLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgBookMarkLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/BookMarkLineThin.tsx
+++ b/packages/components/src/Icon/generated/BookMarkLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgBookMarkLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgBookMarkLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CalendarFill.tsx
+++ b/packages/components/src/Icon/generated/CalendarFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCalendarFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCalendarFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CalendarLineBold.tsx
+++ b/packages/components/src/Icon/generated/CalendarLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCalendarLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCalendarLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CalendarLineRegular.tsx
+++ b/packages/components/src/Icon/generated/CalendarLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCalendarLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCalendarLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CalendarLineThin.tsx
+++ b/packages/components/src/Icon/generated/CalendarLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCalendarLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCalendarLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CameraFill.tsx
+++ b/packages/components/src/Icon/generated/CameraFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCameraFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCameraFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CameraLineBold.tsx
+++ b/packages/components/src/Icon/generated/CameraLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCameraLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCameraLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CameraLineRegular.tsx
+++ b/packages/components/src/Icon/generated/CameraLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCameraLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCameraLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CameraLineThin.tsx
+++ b/packages/components/src/Icon/generated/CameraLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCameraLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCameraLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CartFill.tsx
+++ b/packages/components/src/Icon/generated/CartFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCartFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCartFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CartLineBold.tsx
+++ b/packages/components/src/Icon/generated/CartLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCartLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCartLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CartLineRegular.tsx
+++ b/packages/components/src/Icon/generated/CartLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCartLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCartLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CartLineThin.tsx
+++ b/packages/components/src/Icon/generated/CartLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCartLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCartLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CertificationFill.tsx
+++ b/packages/components/src/Icon/generated/CertificationFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCertificationFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCertificationFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CertificationLineBold.tsx
+++ b/packages/components/src/Icon/generated/CertificationLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCertificationLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCertificationLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CertificationLineRegular.tsx
+++ b/packages/components/src/Icon/generated/CertificationLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCertificationLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCertificationLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CertificationLineThin.tsx
+++ b/packages/components/src/Icon/generated/CertificationLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCertificationLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCertificationLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChatFill.tsx
+++ b/packages/components/src/Icon/generated/ChatFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChatFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChatFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChatLineBold.tsx
+++ b/packages/components/src/Icon/generated/ChatLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChatLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChatLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChatLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ChatLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChatLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChatLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChatLineThin.tsx
+++ b/packages/components/src/Icon/generated/ChatLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChatLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChatLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CheckCircleFill.tsx
+++ b/packages/components/src/Icon/generated/CheckCircleFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCheckCircleFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCheckCircleFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CheckCircleLineBold.tsx
+++ b/packages/components/src/Icon/generated/CheckCircleLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCheckCircleLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCheckCircleLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CheckCircleLineRegular.tsx
+++ b/packages/components/src/Icon/generated/CheckCircleLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCheckCircleLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCheckCircleLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CheckCircleLineThin.tsx
+++ b/packages/components/src/Icon/generated/CheckCircleLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCheckCircleLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCheckCircleLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CheckLineBold.tsx
+++ b/packages/components/src/Icon/generated/CheckLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCheckLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCheckLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CheckLineRegular.tsx
+++ b/packages/components/src/Icon/generated/CheckLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCheckLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCheckLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CheckLineThin.tsx
+++ b/packages/components/src/Icon/generated/CheckLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCheckLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCheckLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronDownLineBold.tsx
+++ b/packages/components/src/Icon/generated/ChevronDownLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronDownLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronDownLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronDownLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ChevronDownLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronDownLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronDownLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronDownLineThin.tsx
+++ b/packages/components/src/Icon/generated/ChevronDownLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronDownLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronDownLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronLeftLineBold.tsx
+++ b/packages/components/src/Icon/generated/ChevronLeftLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronLeftLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronLeftLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronLeftLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ChevronLeftLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronLeftLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronLeftLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronLeftLineThin.tsx
+++ b/packages/components/src/Icon/generated/ChevronLeftLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronLeftLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronLeftLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronRightLineBold.tsx
+++ b/packages/components/src/Icon/generated/ChevronRightLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronRightLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronRightLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronRightLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ChevronRightLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronRightLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronRightLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronRightLineThin.tsx
+++ b/packages/components/src/Icon/generated/ChevronRightLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronRightLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronRightLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronUpLineBold.tsx
+++ b/packages/components/src/Icon/generated/ChevronUpLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronUpLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronUpLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronUpLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ChevronUpLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronUpLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronUpLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ChevronUpLineThin.tsx
+++ b/packages/components/src/Icon/generated/ChevronUpLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgChevronUpLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgChevronUpLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ClockFill.tsx
+++ b/packages/components/src/Icon/generated/ClockFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgClockFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgClockFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ClockLineBold.tsx
+++ b/packages/components/src/Icon/generated/ClockLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgClockLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgClockLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ClockLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ClockLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgClockLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgClockLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ClockLineThin.tsx
+++ b/packages/components/src/Icon/generated/ClockLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgClockLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgClockLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CloseLineBold.tsx
+++ b/packages/components/src/Icon/generated/CloseLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCloseLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCloseLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CloseLineRegular.tsx
+++ b/packages/components/src/Icon/generated/CloseLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCloseLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCloseLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CloseLineThin.tsx
+++ b/packages/components/src/Icon/generated/CloseLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCloseLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCloseLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CommentFill.tsx
+++ b/packages/components/src/Icon/generated/CommentFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCommentFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCommentFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CommentLineBold.tsx
+++ b/packages/components/src/Icon/generated/CommentLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCommentLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCommentLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CommentLineRegular.tsx
+++ b/packages/components/src/Icon/generated/CommentLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCommentLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCommentLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CommentLineThin.tsx
+++ b/packages/components/src/Icon/generated/CommentLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCommentLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCommentLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CompassFill.tsx
+++ b/packages/components/src/Icon/generated/CompassFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCompassFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCompassFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CompassLineBold.tsx
+++ b/packages/components/src/Icon/generated/CompassLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCompassLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCompassLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CompassLineRegular.tsx
+++ b/packages/components/src/Icon/generated/CompassLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCompassLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCompassLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CompassLineThin.tsx
+++ b/packages/components/src/Icon/generated/CompassLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCompassLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCompassLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CopyContentsFill.tsx
+++ b/packages/components/src/Icon/generated/CopyContentsFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCopyContentsFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCopyContentsFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CopyContentsLineBold.tsx
+++ b/packages/components/src/Icon/generated/CopyContentsLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCopyContentsLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCopyContentsLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CopyContentsLineRegular.tsx
+++ b/packages/components/src/Icon/generated/CopyContentsLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCopyContentsLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCopyContentsLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/CopyContentsLineThin.tsx
+++ b/packages/components/src/Icon/generated/CopyContentsLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgCopyContentsLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgCopyContentsLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/DeleteFill.tsx
+++ b/packages/components/src/Icon/generated/DeleteFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgDeleteFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgDeleteFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/DeleteLineBold.tsx
+++ b/packages/components/src/Icon/generated/DeleteLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgDeleteLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgDeleteLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/DeleteLineRegular.tsx
+++ b/packages/components/src/Icon/generated/DeleteLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgDeleteLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgDeleteLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/DeleteLineThin.tsx
+++ b/packages/components/src/Icon/generated/DeleteLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgDeleteLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgDeleteLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/DownloadFill.tsx
+++ b/packages/components/src/Icon/generated/DownloadFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgDownloadFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgDownloadFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/DownloadLineBold.tsx
+++ b/packages/components/src/Icon/generated/DownloadLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgDownloadLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgDownloadLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/DownloadLineRegular.tsx
+++ b/packages/components/src/Icon/generated/DownloadLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgDownloadLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgDownloadLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/DownloadLineThin.tsx
+++ b/packages/components/src/Icon/generated/DownloadLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgDownloadLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgDownloadLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EditCutFill.tsx
+++ b/packages/components/src/Icon/generated/EditCutFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEditCutFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEditCutFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EditCutLineBold.tsx
+++ b/packages/components/src/Icon/generated/EditCutLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEditCutLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEditCutLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EditCutLineRegular.tsx
+++ b/packages/components/src/Icon/generated/EditCutLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEditCutLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEditCutLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EditCutLineThin.tsx
+++ b/packages/components/src/Icon/generated/EditCutLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEditCutLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEditCutLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EditFill.tsx
+++ b/packages/components/src/Icon/generated/EditFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEditFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEditFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EditLineBold.tsx
+++ b/packages/components/src/Icon/generated/EditLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEditLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEditLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EditLineRegular.tsx
+++ b/packages/components/src/Icon/generated/EditLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEditLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEditLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EditLineThin.tsx
+++ b/packages/components/src/Icon/generated/EditLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEditLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEditLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EyeFill.tsx
+++ b/packages/components/src/Icon/generated/EyeFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEyeFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEyeFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EyeLineBold.tsx
+++ b/packages/components/src/Icon/generated/EyeLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEyeLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEyeLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EyeLineRegular.tsx
+++ b/packages/components/src/Icon/generated/EyeLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEyeLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEyeLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EyeLineThin.tsx
+++ b/packages/components/src/Icon/generated/EyeLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEyeLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEyeLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EyeSlashFill.tsx
+++ b/packages/components/src/Icon/generated/EyeSlashFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEyeSlashFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEyeSlashFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EyeSlashLineBold.tsx
+++ b/packages/components/src/Icon/generated/EyeSlashLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEyeSlashLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEyeSlashLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EyeSlashLineRegular.tsx
+++ b/packages/components/src/Icon/generated/EyeSlashLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEyeSlashLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEyeSlashLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/EyeSlashLineThin.tsx
+++ b/packages/components/src/Icon/generated/EyeSlashLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgEyeSlashLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgEyeSlashLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/FarmFill.tsx
+++ b/packages/components/src/Icon/generated/FarmFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgFarmFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgFarmFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/FarmLineBold.tsx
+++ b/packages/components/src/Icon/generated/FarmLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgFarmLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgFarmLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/FarmLineRegular.tsx
+++ b/packages/components/src/Icon/generated/FarmLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgFarmLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgFarmLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/FarmLineThin.tsx
+++ b/packages/components/src/Icon/generated/FarmLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgFarmLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgFarmLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HeartFill.tsx
+++ b/packages/components/src/Icon/generated/HeartFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHeartFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHeartFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HeartLineBold.tsx
+++ b/packages/components/src/Icon/generated/HeartLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHeartLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHeartLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HeartLineRegular.tsx
+++ b/packages/components/src/Icon/generated/HeartLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHeartLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHeartLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HeartLineThin.tsx
+++ b/packages/components/src/Icon/generated/HeartLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHeartLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHeartLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HelpFill.tsx
+++ b/packages/components/src/Icon/generated/HelpFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHelpFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHelpFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HelpLineBold.tsx
+++ b/packages/components/src/Icon/generated/HelpLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHelpLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHelpLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HelpLineRegular.tsx
+++ b/packages/components/src/Icon/generated/HelpLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHelpLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHelpLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HelpLineThin.tsx
+++ b/packages/components/src/Icon/generated/HelpLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHelpLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHelpLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HomeFill.tsx
+++ b/packages/components/src/Icon/generated/HomeFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHomeFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHomeFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HomeLineBold.tsx
+++ b/packages/components/src/Icon/generated/HomeLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHomeLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHomeLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HomeLineRegular.tsx
+++ b/packages/components/src/Icon/generated/HomeLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHomeLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHomeLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/HomeLineThin.tsx
+++ b/packages/components/src/Icon/generated/HomeLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgHomeLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgHomeLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ImageFill.tsx
+++ b/packages/components/src/Icon/generated/ImageFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgImageFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgImageFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ImageLineBold.tsx
+++ b/packages/components/src/Icon/generated/ImageLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgImageLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgImageLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ImageLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ImageLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgImageLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgImageLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ImageLineThin.tsx
+++ b/packages/components/src/Icon/generated/ImageLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgImageLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgImageLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/InfoFill.tsx
+++ b/packages/components/src/Icon/generated/InfoFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgInfoFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgInfoFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/InfoLineBold.tsx
+++ b/packages/components/src/Icon/generated/InfoLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgInfoLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgInfoLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/InfoLineRegular.tsx
+++ b/packages/components/src/Icon/generated/InfoLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgInfoLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgInfoLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/InfoLineThin.tsx
+++ b/packages/components/src/Icon/generated/InfoLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgInfoLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgInfoLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LinkClipLineBold.tsx
+++ b/packages/components/src/Icon/generated/LinkClipLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLinkClipLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLinkClipLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LinkClipLineRegular.tsx
+++ b/packages/components/src/Icon/generated/LinkClipLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLinkClipLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLinkClipLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LinkClipLineThin.tsx
+++ b/packages/components/src/Icon/generated/LinkClipLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLinkClipLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLinkClipLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LinkCopyLineBold.tsx
+++ b/packages/components/src/Icon/generated/LinkCopyLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLinkCopyLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLinkCopyLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LinkCopyLineRegular.tsx
+++ b/packages/components/src/Icon/generated/LinkCopyLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLinkCopyLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLinkCopyLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LinkCopyLineThin.tsx
+++ b/packages/components/src/Icon/generated/LinkCopyLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLinkCopyLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLinkCopyLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LocationFill.tsx
+++ b/packages/components/src/Icon/generated/LocationFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLocationFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLocationFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LocationFill1.tsx
+++ b/packages/components/src/Icon/generated/LocationFill1.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLocationFill1 = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLocationFill1 = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LocationLineBold.tsx
+++ b/packages/components/src/Icon/generated/LocationLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLocationLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLocationLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LocationLineBold1.tsx
+++ b/packages/components/src/Icon/generated/LocationLineBold1.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLocationLineBold1 = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLocationLineBold1 = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LocationLineRegular.tsx
+++ b/packages/components/src/Icon/generated/LocationLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLocationLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLocationLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LocationLineRegular1.tsx
+++ b/packages/components/src/Icon/generated/LocationLineRegular1.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLocationLineRegular1 = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLocationLineRegular1 = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LocationLineThin.tsx
+++ b/packages/components/src/Icon/generated/LocationLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLocationLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLocationLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/LocationLineThin1.tsx
+++ b/packages/components/src/Icon/generated/LocationLineThin1.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgLocationLineThin1 = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgLocationLineThin1 = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MenuFill.tsx
+++ b/packages/components/src/Icon/generated/MenuFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMenuFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMenuFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MenuLineBold.tsx
+++ b/packages/components/src/Icon/generated/MenuLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMenuLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMenuLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MenuLineRegular.tsx
+++ b/packages/components/src/Icon/generated/MenuLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMenuLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMenuLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MenuLineThin.tsx
+++ b/packages/components/src/Icon/generated/MenuLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMenuLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMenuLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MicFill.tsx
+++ b/packages/components/src/Icon/generated/MicFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMicFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMicFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MicLineBold.tsx
+++ b/packages/components/src/Icon/generated/MicLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMicLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMicLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MicLineRegular.tsx
+++ b/packages/components/src/Icon/generated/MicLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMicLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMicLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MicLineThin.tsx
+++ b/packages/components/src/Icon/generated/MicLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMicLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMicLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MicSlashFill.tsx
+++ b/packages/components/src/Icon/generated/MicSlashFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMicSlashFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMicSlashFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MicSlashLineBold.tsx
+++ b/packages/components/src/Icon/generated/MicSlashLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMicSlashLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMicSlashLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MicSlashLineRegular.tsx
+++ b/packages/components/src/Icon/generated/MicSlashLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMicSlashLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMicSlashLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MicSlashLineThin.tsx
+++ b/packages/components/src/Icon/generated/MicSlashLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMicSlashLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMicSlashLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MinusLineBold.tsx
+++ b/packages/components/src/Icon/generated/MinusLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMinusLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMinusLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MinusLineRegular.tsx
+++ b/packages/components/src/Icon/generated/MinusLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMinusLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMinusLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MinusLineThin.tsx
+++ b/packages/components/src/Icon/generated/MinusLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMinusLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMinusLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MoneyBagFill.tsx
+++ b/packages/components/src/Icon/generated/MoneyBagFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMoneyBagFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMoneyBagFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MoneyBagLineBold.tsx
+++ b/packages/components/src/Icon/generated/MoneyBagLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMoneyBagLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMoneyBagLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MoneyBagLineRegular.tsx
+++ b/packages/components/src/Icon/generated/MoneyBagLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMoneyBagLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMoneyBagLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/MoneyBagLineThin.tsx
+++ b/packages/components/src/Icon/generated/MoneyBagLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgMoneyBagLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgMoneyBagLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NoticeFill.tsx
+++ b/packages/components/src/Icon/generated/NoticeFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNoticeFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNoticeFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NoticeLineBold.tsx
+++ b/packages/components/src/Icon/generated/NoticeLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNoticeLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNoticeLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NoticeLineRegular.tsx
+++ b/packages/components/src/Icon/generated/NoticeLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNoticeLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNoticeLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NoticeLineThin.tsx
+++ b/packages/components/src/Icon/generated/NoticeLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNoticeLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNoticeLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NotificationFill.tsx
+++ b/packages/components/src/Icon/generated/NotificationFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNotificationFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNotificationFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NotificationLineBold.tsx
+++ b/packages/components/src/Icon/generated/NotificationLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNotificationLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNotificationLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NotificationLineRegular.tsx
+++ b/packages/components/src/Icon/generated/NotificationLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNotificationLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNotificationLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NotificationLineThin.tsx
+++ b/packages/components/src/Icon/generated/NotificationLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNotificationLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNotificationLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NotificationSlashFill.tsx
+++ b/packages/components/src/Icon/generated/NotificationSlashFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNotificationSlashFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNotificationSlashFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NotificationSlashLineBold.tsx
+++ b/packages/components/src/Icon/generated/NotificationSlashLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNotificationSlashLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNotificationSlashLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NotificationSlashLineRegular.tsx
+++ b/packages/components/src/Icon/generated/NotificationSlashLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNotificationSlashLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNotificationSlashLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/NotificationSlashLineThin.tsx
+++ b/packages/components/src/Icon/generated/NotificationSlashLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgNotificationSlashLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgNotificationSlashLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PersonCircleFill.tsx
+++ b/packages/components/src/Icon/generated/PersonCircleFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPersonCircleFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPersonCircleFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PersonCircleLineBold.tsx
+++ b/packages/components/src/Icon/generated/PersonCircleLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPersonCircleLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPersonCircleLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PersonCircleLineRegular.tsx
+++ b/packages/components/src/Icon/generated/PersonCircleLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPersonCircleLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPersonCircleLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PersonCircleLineThin.tsx
+++ b/packages/components/src/Icon/generated/PersonCircleLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPersonCircleLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPersonCircleLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PersonFill.tsx
+++ b/packages/components/src/Icon/generated/PersonFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPersonFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPersonFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PersonLineBold.tsx
+++ b/packages/components/src/Icon/generated/PersonLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPersonLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPersonLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PersonLineRegular.tsx
+++ b/packages/components/src/Icon/generated/PersonLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPersonLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPersonLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PersonLineThin.tsx
+++ b/packages/components/src/Icon/generated/PersonLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPersonLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPersonLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PhoneFill.tsx
+++ b/packages/components/src/Icon/generated/PhoneFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPhoneFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPhoneFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PhoneLineBold.tsx
+++ b/packages/components/src/Icon/generated/PhoneLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPhoneLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPhoneLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PhoneLineRegular.tsx
+++ b/packages/components/src/Icon/generated/PhoneLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPhoneLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPhoneLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PhoneLineThin.tsx
+++ b/packages/components/src/Icon/generated/PhoneLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPhoneLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPhoneLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PinFill.tsx
+++ b/packages/components/src/Icon/generated/PinFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPinFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPinFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PinLineBold.tsx
+++ b/packages/components/src/Icon/generated/PinLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPinLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPinLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PinLineRegular.tsx
+++ b/packages/components/src/Icon/generated/PinLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPinLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPinLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PinLineThin.tsx
+++ b/packages/components/src/Icon/generated/PinLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPinLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPinLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PlayFill.tsx
+++ b/packages/components/src/Icon/generated/PlayFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPlayFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPlayFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PlayLineBold.tsx
+++ b/packages/components/src/Icon/generated/PlayLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPlayLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPlayLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PlayLineRegular.tsx
+++ b/packages/components/src/Icon/generated/PlayLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPlayLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPlayLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PlayLineThin.tsx
+++ b/packages/components/src/Icon/generated/PlayLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPlayLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPlayLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PlusCircleFill.tsx
+++ b/packages/components/src/Icon/generated/PlusCircleFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPlusCircleFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPlusCircleFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PlusCircleLineBold.tsx
+++ b/packages/components/src/Icon/generated/PlusCircleLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPlusCircleLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPlusCircleLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PlusCircleLineRegular.tsx
+++ b/packages/components/src/Icon/generated/PlusCircleLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPlusCircleLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPlusCircleLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PlusCircleLineThin.tsx
+++ b/packages/components/src/Icon/generated/PlusCircleLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPlusCircleLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPlusCircleLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PlusLineBold.tsx
+++ b/packages/components/src/Icon/generated/PlusLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPlusLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPlusLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PlusLineRegular.tsx
+++ b/packages/components/src/Icon/generated/PlusLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPlusLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPlusLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PlusLineThin.tsx
+++ b/packages/components/src/Icon/generated/PlusLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPlusLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPlusLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PostSquareFill.tsx
+++ b/packages/components/src/Icon/generated/PostSquareFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPostSquareFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPostSquareFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PostSquareLineBold.tsx
+++ b/packages/components/src/Icon/generated/PostSquareLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPostSquareLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPostSquareLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PostSquareLineRegular.tsx
+++ b/packages/components/src/Icon/generated/PostSquareLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPostSquareLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPostSquareLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/PostSquareLineThin.tsx
+++ b/packages/components/src/Icon/generated/PostSquareLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgPostSquareLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgPostSquareLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/RefreshLineBold.tsx
+++ b/packages/components/src/Icon/generated/RefreshLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgRefreshLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgRefreshLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/RefreshLineRegular.tsx
+++ b/packages/components/src/Icon/generated/RefreshLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgRefreshLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgRefreshLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/RefreshLineThin.tsx
+++ b/packages/components/src/Icon/generated/RefreshLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgRefreshLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgRefreshLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SearchFill.tsx
+++ b/packages/components/src/Icon/generated/SearchFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSearchFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSearchFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SearchLineBold.tsx
+++ b/packages/components/src/Icon/generated/SearchLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSearchLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSearchLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SearchLineRegular.tsx
+++ b/packages/components/src/Icon/generated/SearchLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSearchLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSearchLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SearchLineThin.tsx
+++ b/packages/components/src/Icon/generated/SearchLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSearchLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSearchLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SeeMoreFill.tsx
+++ b/packages/components/src/Icon/generated/SeeMoreFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSeeMoreFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSeeMoreFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SeeMoreLineBold.tsx
+++ b/packages/components/src/Icon/generated/SeeMoreLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSeeMoreLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSeeMoreLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SeeMoreLineRegular.tsx
+++ b/packages/components/src/Icon/generated/SeeMoreLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSeeMoreLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSeeMoreLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SeeMoreLineThin.tsx
+++ b/packages/components/src/Icon/generated/SeeMoreLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSeeMoreLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSeeMoreLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SendPlaneFill.tsx
+++ b/packages/components/src/Icon/generated/SendPlaneFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSendPlaneFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSendPlaneFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SendPlaneLineBold.tsx
+++ b/packages/components/src/Icon/generated/SendPlaneLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSendPlaneLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSendPlaneLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SendPlaneLineRegular.tsx
+++ b/packages/components/src/Icon/generated/SendPlaneLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSendPlaneLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSendPlaneLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SendPlaneLineThin.tsx
+++ b/packages/components/src/Icon/generated/SendPlaneLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSendPlaneLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSendPlaneLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SettingFill.tsx
+++ b/packages/components/src/Icon/generated/SettingFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSettingFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSettingFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SettingLineBold.tsx
+++ b/packages/components/src/Icon/generated/SettingLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSettingLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSettingLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SettingLineRegular.tsx
+++ b/packages/components/src/Icon/generated/SettingLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSettingLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSettingLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/SettingLineThin.tsx
+++ b/packages/components/src/Icon/generated/SettingLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgSettingLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgSettingLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareAndroidFill.tsx
+++ b/packages/components/src/Icon/generated/ShareAndroidFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareAndroidFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareAndroidFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareAndroidLineBold.tsx
+++ b/packages/components/src/Icon/generated/ShareAndroidLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareAndroidLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareAndroidLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareAndroidLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ShareAndroidLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareAndroidLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareAndroidLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareAndroidLineThin.tsx
+++ b/packages/components/src/Icon/generated/ShareAndroidLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareAndroidLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareAndroidLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareArrowFill.tsx
+++ b/packages/components/src/Icon/generated/ShareArrowFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareArrowFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareArrowFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareArrowLineBold.tsx
+++ b/packages/components/src/Icon/generated/ShareArrowLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareArrowLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareArrowLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareArrowLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ShareArrowLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareArrowLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareArrowLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareArrowLineThin.tsx
+++ b/packages/components/src/Icon/generated/ShareArrowLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareArrowLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareArrowLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareIosFill.tsx
+++ b/packages/components/src/Icon/generated/ShareIosFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareIosFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareIosFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareIosLineBold.tsx
+++ b/packages/components/src/Icon/generated/ShareIosLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareIosLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareIosLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareIosLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ShareIosLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareIosLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareIosLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShareIosLineThin.tsx
+++ b/packages/components/src/Icon/generated/ShareIosLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShareIosLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShareIosLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShoppingBasketFill.tsx
+++ b/packages/components/src/Icon/generated/ShoppingBasketFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShoppingBasketFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShoppingBasketFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShoppingBasketLineBold.tsx
+++ b/packages/components/src/Icon/generated/ShoppingBasketLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShoppingBasketLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShoppingBasketLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShoppingBasketLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ShoppingBasketLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShoppingBasketLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShoppingBasketLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ShoppingBasketLineThin.tsx
+++ b/packages/components/src/Icon/generated/ShoppingBasketLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgShoppingBasketLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgShoppingBasketLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ThumbUpFill.tsx
+++ b/packages/components/src/Icon/generated/ThumbUpFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgThumbUpFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgThumbUpFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ThumbUpLineBold.tsx
+++ b/packages/components/src/Icon/generated/ThumbUpLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgThumbUpLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgThumbUpLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ThumbUpLineRegular.tsx
+++ b/packages/components/src/Icon/generated/ThumbUpLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgThumbUpLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgThumbUpLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/ThumbUpLineThin.tsx
+++ b/packages/components/src/Icon/generated/ThumbUpLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgThumbUpLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgThumbUpLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/TouchFill.tsx
+++ b/packages/components/src/Icon/generated/TouchFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgTouchFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgTouchFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/TouchLineBold.tsx
+++ b/packages/components/src/Icon/generated/TouchLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgTouchLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgTouchLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/TouchLineRegular.tsx
+++ b/packages/components/src/Icon/generated/TouchLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgTouchLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgTouchLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/TouchLineThin.tsx
+++ b/packages/components/src/Icon/generated/TouchLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgTouchLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgTouchLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/TrashFill.tsx
+++ b/packages/components/src/Icon/generated/TrashFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgTrashFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgTrashFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/TrashLineBold.tsx
+++ b/packages/components/src/Icon/generated/TrashLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgTrashLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgTrashLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/TrashLineRegular.tsx
+++ b/packages/components/src/Icon/generated/TrashLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgTrashLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgTrashLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/TrashLineThin.tsx
+++ b/packages/components/src/Icon/generated/TrashLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgTrashLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgTrashLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/VideoFill.tsx
+++ b/packages/components/src/Icon/generated/VideoFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgVideoFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgVideoFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/VideoLineBold.tsx
+++ b/packages/components/src/Icon/generated/VideoLineBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgVideoLineBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgVideoLineBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/VideoLineRegular.tsx
+++ b/packages/components/src/Icon/generated/VideoLineRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgVideoLineRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgVideoLineRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/VideoLineThin.tsx
+++ b/packages/components/src/Icon/generated/VideoLineThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgVideoLineThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgVideoLineThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/WebBold.tsx
+++ b/packages/components/src/Icon/generated/WebBold.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgWebBold = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgWebBold = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/WebFill.tsx
+++ b/packages/components/src/Icon/generated/WebFill.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgWebFill = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgWebFill = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/WebRegular.tsx
+++ b/packages/components/src/Icon/generated/WebRegular.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgWebRegular = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgWebRegular = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/generated/WebThin.tsx
+++ b/packages/components/src/Icon/generated/WebThin.tsx
@@ -3,7 +3,7 @@ import { colorMap } from "@greenlabs/formula-design-token"
 import { convertSizeToPx } from "../utils"
 import type { IconProps } from "../types"
 const SvgWebThin = (
-  { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+  { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
   ref: Ref<SVGSVGElement>
 ) => {
   const finalSize = sizePx ? sizePx : convertSizeToPx(size)
@@ -14,9 +14,7 @@ const SvgWebThin = (
       height={finalSize}
       fill={fill}
       xmlns="http://www.w3.org/2000/svg"
-      style={style}
       viewBox="0 0 48 48"
-      className={className}
       ref={ref}
       {...props}
     >

--- a/packages/components/src/Icon/templates/svgr-cli.template.js
+++ b/packages/components/src/Icon/templates/svgr-cli.template.js
@@ -6,7 +6,7 @@ const template = ({ jsx, componentName, exports }, { tpl }) => {
   import type { IconProps } from "../types"
 
   const ${componentName} = (
-    { size = "xl", sizePx, style, className, color, ...props }: IconProps,
+    { size = "xl", sizePx, color = "gray-90", ...props }: IconProps,
     ref: Ref<SVGSVGElement>  
   ) => {
     const finalSize = sizePx ? sizePx : convertSizeToPx(size)

--- a/packages/components/src/Icon/types.ts
+++ b/packages/components/src/Icon/types.ts
@@ -3,11 +3,9 @@ import type { colorMap } from "@greenlabs/formula-design-token"
 export type size = "pc" | "xl" | "lg" | "sm" | "xs"
 
 export interface IconBaseProps {
-  className?: string
   color?: keyof typeof colorMap
   size?: size
   sizePx?: number
-  style?: React.CSSProperties
 }
 
 export type IconProps = IconBaseProps & SVGProps<SVGSVGElement>


### PR DESCRIPTION
작업내용
-
- 아이콘 컴포넌트 내부에있던 prop type을 분리했습니다.
- classname 및 style prop에 대해 타입을 재정의하는 부분을 제거했습니다.
- color prop에 대한 기본값을 추가합니다. (`"gray-90"`)