### PR TITLE
fix: 아이콘 갤러리의 레이아웃 수정

### DIFF
--- a/packages/components/src/Icon/Icon.stories.tsx
+++ b/packages/components/src/Icon/Icon.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react"
+import React from "react"
 import type { ComponentMeta, ComponentStory } from "@storybook/react"
 import { colorMap } from "@greenlabs/formula-design-token"
 import * as IconComponents from "./generated"
@@ -50,13 +50,13 @@ export const IconGallery: ComponentStory<typeof IconComponents["AppleFill"]> = (
   args
 ) => {
   return (
-    <ThemeScope>
+    <>
       {Object.entries(IconComponents).map(([name, Component]) => (
         <IconItem name={name}>
           <Component {...args} />
         </IconItem>
       ))}
-    </ThemeScope>
+    </>
   )
 }
 
@@ -79,19 +79,21 @@ export default {
   },
   decorators: [
     (Story) => (
-      <div
-        style={{
-          marginTop: "20px",
-          marginBottom: "20px",
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
-          overflow: "hidden",
-          flexFlow: "wrap",
-          gap: 30,
-        }}
-      >
-        <Story />
-      </div>
+      <ThemeScope>
+        <div
+          style={{
+            marginTop: "20px",
+            marginBottom: "20px",
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
+            overflow: "hidden",
+            flexFlow: "wrap",
+            gap: 30,
+          }}
+        >
+          <Story />
+        </div>
+      </ThemeScope>
     ),
   ],
 } as ComponentMeta<typeof IconComponents["AppleFill"]>


### PR DESCRIPTION
1컬럼으로만 나오고 있던 아이콘 갤러리를 수정한 커밋입니다.

|AS-IS| TO-BE|
| ---| ---|
|<img width="706" alt="image" src="https://user-images.githubusercontent.com/105708964/207296526-050d2592-42dd-4dfc-a8dc-7fdff689b116.png">|<img width="1595" alt="image" src="https://user-images.githubusercontent.com/105708964/207296601-5ac8cc12-1658-4055-8f2d-fd4fd58fa7d1.png">|

